### PR TITLE
Link to chrome webstore page, instead of raw file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It adds to Voat.co the possiblity to:
 
 ---
 
-## [Chrome extension](https://github.com/HorzaGobuchul/Amateur-Voat-Enhancements/raw/master/Chrome/Amateur_Voat_Enhancements.crx) (beta).
+## [Chrome extension](https://chrome.google.com/webstore/detail/amateur-voat-enhancements/clnkijlaikabdbjejkikchdhkfkehhnf/related) (beta).
 
 ---
 


### PR DESCRIPTION
It's not an easy process to install a chrome plugin from a raw file. Much better if you link to the webstore page.
